### PR TITLE
fix: Configure UTF-8 encoding for Maven build and plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,40 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
   <packaging>pom</packaging>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
+          <configuration>
+            <encoding>${project.build.sourceEncoding}</encoding>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+          <configuration>
+            <encoding>${project.build.sourceEncoding}</encoding>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.2.5</version>
+          <configuration>
+            <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
   <modules>
     <module>modules/geometry</module> 
     <module>modules/rendering</module>


### PR DESCRIPTION
I've set project-wide UTF-8 encoding to resolve 'unmappable character' errors and platform-dependent build warnings for you.

Here's what I did:
1. Defined `project.build.sourceEncoding` and `project.reporting.outputEncoding` properties as UTF-8 in the parent POM.
2. Configured `maven-compiler-plugin` in `<pluginManagement>` to use `${project.build.sourceEncoding}` for compiling source files.
3. Configured `maven-resources-plugin` in `<pluginManagement>` to use `${project.build.sourceEncoding}` for filtering resources.
4. Configured `maven-surefire-plugin` in `<pluginManagement>` to use `-Dfile.encoding=${project.build.sourceEncoding}` in `argLine`, ensuring tests also run with UTF-8.

These changes ensure that all modules inherit consistent UTF-8 encoding settings, making the build platform-independent and preventing issues with special characters in source files or file paths.