### PR TITLE
Fix compilation errors in CustomCadPanel and Point2D

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,6 +86,10 @@ Este documento detalha o status atual de implementação das funcionalidades pla
 - `[ ] (P3)` **Integrar Ciclo de Vida do Módulo GUI com Kernel via ModuleInterface**
   - *Detalhe:* Utilizar a `ModuleInterface` implementada por `com.cad.gui.MainFrame` para que o `Kernel` (ou `ModuleManager`) possa gerenciar o ciclo de vida do módulo `gui` (chamando `init`, `start`, `stop`, `destroy`).
 
+## Manutenção e Melhorias Recentes
+- `[X]` **Correções Diversas e Melhorias de Código:**
+  - *Detalhe:* Corrigidas referências de `Point2D.Double` para `java.awt.geom.Point2D.Double` em `CustomCadPanel.java` para evitar ambiguidades. Adicionado método `distanceTo(Point2D other)` em `Point2D.java` (dxflib) para cálculos de distância. Corrigida a forma de obtenção de diagramas SVG da biblioteca SVG Salamander em `CustomCadPanel.java`, utilizando `getURIs()` e `getDiagram()` em vez de `getDiagramMap()`.
+
 ## Módulo Leitor DXF (dxflib)
 - `[X]` Definição do Escopo Inicial (Entidades DXF, Versão ASCII, AutoCAD 2000/2004, Layers/Cores)
 - `[X]` Análise de Referência (Kabeja - conceitual)

--- a/dxflib/src/main/java/com/cad/dxflib/common/Point2D.java
+++ b/dxflib/src/main/java/com/cad/dxflib/common/Point2D.java
@@ -11,6 +11,12 @@ public class Point2D {
         this.y = y;
     }
 
+    public double distanceTo(Point2D other) {
+        double deltaX = other.x - this.x;
+        double deltaY = other.y - this.y;
+        return Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gui/src/main/java/com/cad/gui/CustomCadPanel.java
+++ b/gui/src/main/java/com/cad/gui/CustomCadPanel.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 // java.net.URI will be needed for diagram lookup from SVGUniverse
 import java.net.URI;
+import java.util.Iterator;
 
 
 public class CustomCadPanel extends JPanel {
@@ -113,8 +114,8 @@ public class CustomCadPanel extends JPanel {
             viewTransform.translate(translateX, translateY);
             viewTransform.scale(currentScale, currentScale);
             AffineTransform inverseTransform = viewTransform.createInverse();
-            Point2D.Double modelCoords = new Point2D.Double();
-            inverseTransform.transform(new Point2D.Double(screenPoint.x, screenPoint.y), modelCoords);
+            java.awt.geom.Point2D.Double modelCoords = new java.awt.geom.Point2D.Double();
+            inverseTransform.transform(new java.awt.geom.Point2D.Double(screenPoint.x, screenPoint.y), modelCoords);
             return new Point2D(modelCoords.x, modelCoords.y);
         } catch (NoninvertibleTransformException e) {
             e.printStackTrace(); // Should not happen with typical view transforms
@@ -248,9 +249,9 @@ public class CustomCadPanel extends JPanel {
             if (svgUniverseFromDxf != null) {
                 // Try to get the diagram by the name used when loading, or get the first one
                 URI diagramUri = null;
-                if (svgUniverseFromDxf.getDiagramMap().size() > 0) {
-                     // Attempt to get the first diagram loaded if the name isn't fixed/known easily
-                    diagramUri = svgUniverseFromDxf.getDiagramMap().keySet().stream().findFirst().orElse(null);
+                Iterator<URI> uriIter = svgUniverseFromDxf.getURIs();
+                if (uriIter.hasNext()) {
+                    diagramUri = uriIter.next();
                 }
 
                 if (diagramUri != null) {


### PR DESCRIPTION
This commit addresses several compilation errors:

- Corrected `Point2D.Double` references in `CustomCadPanel.java` to use the fully qualified `java.awt.geom.Point2D.Double`.
- Added the missing `distanceTo(Point2D other)` method to `dxflib/src/main/java/com/cad/dxflib/common/Point2D.java`.
- Updated `CustomCadPanel.java` to use the correct methods (`getURIs()` and `getDiagram()`) for retrieving diagrams from `com.kitfox.svg.SVGUniverse`.

Additionally, the `ROADMAP.md` has been updated to reflect these changes.