### PR TITLE
Fix compilation and runtime errors in CustomCadPanel and Point2D

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,7 +88,7 @@ Este documento detalha o status atual de implementação das funcionalidades pla
 
 ## Manutenção e Melhorias Recentes
 - `[X]` **Correções Diversas e Melhorias de Código:**
-  - *Detalhe:* Corrigidas referências de `Point2D.Double` para `java.awt.geom.Point2D.Double` em `CustomCadPanel.java` para evitar ambiguidades. Adicionado método `distanceTo(Point2D other)` em `Point2D.java` (dxflib) para cálculos de distância. Corrigida a forma de obtenção de diagramas SVG da biblioteca SVG Salamander em `CustomCadPanel.java`, utilizando `getURIs()` e `getDiagram()` em vez de `getDiagramMap()`.
+  - *Detalhe:* Corrigidas referências de `Point2D.Double` para `java.awt.geom.Point2D.Double` em `CustomCadPanel.java` para evitar ambiguidades. Adicionado método `distanceTo(Point2D other)` em `Point2D.java` (dxflib) para cálculos de distância. Refinada a obtenção de diagramas SVG em `CustomCadPanel.java`, armazenando o nome do diagrama carregado (`currentDiagramName`) e utilizando `svgUniverseFromDxf.getStreamBuiltURI(this.currentDiagramName)` para recuperação precisa do diagrama.
 
 ## Módulo Leitor DXF (dxflib)
 - `[X]` Definição do Escopo Inicial (Entidades DXF, Versão ASCII, AutoCAD 2000/2004, Layers/Cores)


### PR DESCRIPTION
This commit addresses several issues:

- Corrected `Point2D.Double` references in `CustomCadPanel.java` to use the fully qualified `java.awt.geom.Point2D.Double`.
- Added the missing `distanceTo(Point2D other)` method to `dxflib/src/main/java/com/cad/dxflib/common/Point2D.java`.
- Fixed SVG diagram retrieval in `CustomCadPanel.java`. It now stores the diagram name upon loading and uses `SVGUniverse.getStreamBuiltURI(diagramName)` followed by `SVGUniverse.getDiagram(uri)` to accurately fetch the diagram. This resolves the previous `cannot find symbol` error for `getURIs()`.

Additionally, the `ROADMAP.md` has been updated to reflect these changes.