### PR TITLE
Fix: Add missing slf4j-api dependency to rendering module

### DIFF
--- a/modules/rendering/pom.xml
+++ b/modules/rendering/pom.xml
@@ -38,6 +38,12 @@
         <version>1.0-SNAPSHOT</version>
         <scope>compile</scope>
     </dependency>
+    <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.32</version>
+        <scope>compile</scope>
+    </dependency>
 
     <!-- Apache Batik Dependencies -->
 


### PR DESCRIPTION
Resolves a compilation error 'cannot find symbol: class Logger' in DxfRenderService.java.

The slf4j-api dependency was missing from the pom.xml of the 'rendering' module, causing the SLF4J Logger class to be unavailable during compilation, even though import statements were present in the Java source file.

This commit adds 'org.slf4j:slf4j-api:1.7.32' with compile scope to modules/rendering/pom.xml.